### PR TITLE
Fixed rails gem after breaking changes

### DIFF
--- a/dante2.gemspec
+++ b/dante2.gemspec
@@ -13,7 +13,5 @@ Gem::Specification.new do |gem|
   gem.homepage      = "http://michelson.github.io/Dante/"
 
   gem.files         = `git ls-files`.split($/)
-  gem.executables   = gem.files.grep(%r{^bin/}).map{ |f| File.basename(f) }
-  gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
-  gem.require_paths = ["lib"]
+  gem.require_paths = ["rb_lib"]
 end

--- a/rb_lib/dante2-editor/rails.rb
+++ b/rb_lib/dante2-editor/rails.rb
@@ -1,16 +1,14 @@
 module Dante2Editor
   class Engine < ::Rails::Engine
 
-    config.generators do |g|
-
-      config.assets.paths << Dante2Editor::Engine.root.join("docs", "fonts")
-      config.assets.paths << Dante2Editor::Engine.root.join("docs", "images")
-      config.assets.paths << Dante2Editor::Engine.root.join("docs")
-
-      config.assets.paths << Dante2Editor::Engine.root.join("app", "styles")
-
-
+    # Redefines Rails::Engine::find_root to search in `rb_lib` instead of `lib`
+    def self.find_root(from)
+      find_root_with_flag "rb_lib", from
     end
+
+    # Make the compiled assets in docs/* available to the AssetPipeline
+    config.assets.paths << Dante2Editor::Engine.root.join("docs", "fonts")
+    config.assets.paths << Dante2Editor::Engine.root.join("docs")
 
   end
 end

--- a/rb_lib/dante2-editor/rails.rb
+++ b/rb_lib/dante2-editor/rails.rb
@@ -6,16 +6,9 @@ module Dante2Editor
       find_root_with_flag "rb_lib", from
     end
 
-    config.generators do |g|
-
-      config.assets.paths << Dante2Editor::Engine.root.join("docs", "fonts")
-      config.assets.paths << Dante2Editor::Engine.root.join("docs", "images")
-      config.assets.paths << Dante2Editor::Engine.root.join("docs")
-
-      config.assets.paths << Dante2Editor::Engine.root.join("app", "styles")
-
-
-    end
+    # Make the compiled assets in docs/* available to the AssetPipeline
+    config.assets.paths << Dante2Editor::Engine.root.join("docs", "fonts")
+    config.assets.paths << Dante2Editor::Engine.root.join("docs")
 
   end
 end

--- a/rb_lib/dante2-editor/rails.rb
+++ b/rb_lib/dante2-editor/rails.rb
@@ -6,9 +6,16 @@ module Dante2Editor
       find_root_with_flag "rb_lib", from
     end
 
-    # Make the compiled assets in docs/* available to the AssetPipeline
-    config.assets.paths << Dante2Editor::Engine.root.join("docs", "fonts")
-    config.assets.paths << Dante2Editor::Engine.root.join("docs")
+    config.generators do |g|
+
+      config.assets.paths << Dante2Editor::Engine.root.join("docs", "fonts")
+      config.assets.paths << Dante2Editor::Engine.root.join("docs", "images")
+      config.assets.paths << Dante2Editor::Engine.root.join("docs")
+
+      config.assets.paths << Dante2Editor::Engine.root.join("app", "styles")
+
+
+    end
 
   end
 end


### PR DESCRIPTION
The latest changes, moving the rails stuff into `rb_lib` has broken the Rails gem.

I've fixed it in this PR.

Have a look at  [this method](https://github.com/rails/rails/blob/8898a0ae2a0d5c8826fe08bbf4ccd10745802f9e/railties/lib/rails/engine.rb#L370-L372) and [this method](https://github.com/rails/rails/blob/8898a0ae2a0d5c8826fe08bbf4ccd10745802f9e/railties/lib/rails/engine.rb#L663-L674) to get a better understanding of what went wrong