### PR TITLE
poc for widget delete

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,0 +1,27 @@
+module.exports = {
+    "extends": "standard",
+    "parser": "babel-eslint",
+    "rules": {
+      "strict": 0,
+      "indent": [2, 2, { "SwitchCase": 1 }],
+      "quotes": [2, "single"],
+      "linebreak-style": [2, "unix"],
+      "semi": [2, "always"]
+    },
+    "env": {
+      "es6": true,
+      "browser": true
+    },
+    "extends": "eslint:recommended",
+    "ecmaFeatures": {
+      "modules": true,
+      "jsx": true,
+      "experimentalObjectRestSpread": true
+    },
+    "plugins": [
+      "react",
+      "standard",
+      "promise"
+    ]
+
+};

--- a/src/components/dante.js
+++ b/src/components/dante.js
@@ -83,6 +83,9 @@ class Dante {
         const { editorState } = ctx.state
         return ctx.onChange(addNewBlockAt(editorState, block.getKey()))
       },
+      handleDelete(ctx, block){
+        debugger
+      },
       widget_options: {
         displayOnInlineTooltip: true,
         insertion: "upload",

--- a/src/components/dante_editor.js
+++ b/src/components/dante_editor.js
@@ -708,6 +708,16 @@ class DanteEditor extends React.Component {
       return true
     }
 
+    // catch delete, get block, check if has handle delete, then execute it
+    if (command.indexOf('delete') === 0) {
+      let config_block = this.getDataBlock(block)
+      if (config_block && config_block.handleDelete) {
+        config_block.handleDelete(this, block)
+      }
+      return true
+    }
+
+
     const newState = RichUtils.handleKeyCommand(this.state.editorState, command)
     if (newState) {
       this.onChange(newState)
@@ -755,6 +765,8 @@ class DanteEditor extends React.Component {
         return cmd.cmd
       }
       return getDefaultKeyBinding(e)
+    } else if (e.keyCode == 8 || e.keyCode == 46) {
+      return "delete"
     }
 
     return getDefaultKeyBinding(e)


### PR DESCRIPTION
This is a proof of concept for Widget Deletion. 
it assumes a custom configuration where `handleDelete` option is provided for the widget. This test adds a `debugger` on the callback for testing purposes. I've to think about of the design for this implementation on how will be configured. But the main idea is to check on `del` or `backspace` event for widgets that handle deletion and execute it's callback. 
The callback function provides the editor context and the current block with is deleted.

```
handleDelete(ctx, block){
     var url = block.toJS().data.url
     // do your ajax DELETE 
},
```
issue ref: #23 