### PR TITLE
detach the xhr save from checkforStore

### DIFF
--- a/demo/assets/index.html
+++ b/demo/assets/index.html
@@ -44,7 +44,14 @@
             content: window.PocData,
             debug: true,
             data_storage: {
-              url: "http://localhost:3333/store.json"
+              url: "http://localhost:3333/store.json",
+              save_handler: function(ctx, content){
+                console.log("SAVING DATA!!");
+                console.info({
+                  editor_content: JSON.stringify(content),
+                  text_content: ctx.getTextFromEditor(content)
+                });
+              },
             }
           }
         )

--- a/src/components/dante.js
+++ b/src/components/dante.js
@@ -226,7 +226,10 @@ class Dante {
       method: "POST",
       success_handler: null,
       failure_handler: null,
-      interval: 1500
+      interval: 1500,
+      withCredentials: false,
+      crossDomain: false,
+      headers: {},
     }
 
     defaultOptions.default_wrappers = [

--- a/src/utils/save_content.js
+++ b/src/utils/save_content.js
@@ -50,11 +50,18 @@ class SaveBehavior {
     // console.log("CONTENT CHANGED:", isChanged)
 
     if (!isChanged) { return }
-      
+
     this.save(content)
   }
 
   save(content){
+
+    // use save handler from config if exists
+    if (this.config.data_storage.save_handler){
+      this.data_storage.save_handler(JSON.stringify(content))
+      return 
+    }
+
     if (this.config.xhr.before_handler) { this.config.xhr.before_handler() }
     // console.log "SAVING TO: #{@getMethod()} #{@getUrl()}"
 

--- a/src/utils/save_content.js
+++ b/src/utils/save_content.js
@@ -50,7 +50,11 @@ class SaveBehavior {
     // console.log("CONTENT CHANGED:", isChanged)
 
     if (!isChanged) { return }
+      
+    this.save(content)
+  }
 
+  save(content){
     if (this.config.xhr.before_handler) { this.config.xhr.before_handler() }
     // console.log "SAVING TO: #{@getMethod()} #{@getUrl()}"
 

--- a/src/utils/save_content.js
+++ b/src/utils/save_content.js
@@ -35,14 +35,48 @@ class SaveBehavior {
 
   getUrl() {
     let { url } = this.config.data_storage
-    if (typeof(url) === "function") { return url() } else { return url }
+    if (typeof(url) === "function") { 
+      return url() 
+    } else { 
+      return url 
+    }
   }
 
   getMethod() {
     let { method } = this.config.data_storage
-    if (typeof(method) === "function") { return method() } else { return method }
+    if (typeof(method) === "function") { 
+      return method() 
+    } else { 
+      return method 
+    }
   }
 
+  getWithCredentials(){
+    let { withCredentials } = this.config.data_storage
+    if (typeof(withCredentials) === "function") { 
+      return withCredentials() 
+    } else { 
+      return withCredentials 
+    }
+  }
+
+  getCrossDomain(){
+    let { crossDomain } = this.config.data_storage
+    if (typeof(crossDomain) === "function") { 
+      return crossDomain()
+    } else { 
+      return crossDomain 
+    }
+  }
+
+  getHeaders(){
+    let { headers } = this.config.data_storage
+    if (typeof(headers) === "function") { 
+      return headers() 
+    } else { 
+      return headers 
+    }
+  }
 
   checkforStore(content){
     // ENTER DATA STORE
@@ -71,7 +105,10 @@ class SaveBehavior {
       data: {
         editor_content: JSON.stringify(content),
         text_content: this.getTextFromEditor(content)
-      }
+      },
+      withCredentials: this.getWithCredentials(),
+      crossDomain: this.getCrossDomain(),
+      headers: this.getHeaders(),
     })
     .then(result=> {
       // console.log "STORING CONTENT", result

--- a/src/utils/save_content.js
+++ b/src/utils/save_content.js
@@ -58,7 +58,7 @@ class SaveBehavior {
 
     // use save handler from config if exists
     if (this.config.data_storage.save_handler){
-      this.data_storage.save_handler(JSON.stringify(content))
+      this.config.data_storage.save_handler(this, content)
       return 
     }
 


### PR DESCRIPTION
saparate function on `SaveBehavior` class in order to use this without check for store
issue ref #6 #7  

### example: 

the callback function will receive context and content in order to manipulate the data with functions provided from `SaveBehavior`

```js
editor = new Dante(
  ...
  data_storage: {
      url: "http://localhost:3333/store.json",
      save_handler: function(ctx, content){
          console.info({
             editor_content: JSON.stringify(content),
             text_content: ctx.getTextFromEditor(content)
           });
  ...
```