### PR TITLE
Adding support for custom upload handler.

### DIFF
--- a/src/components/blocks/image.js
+++ b/src/components/blocks/image.js
@@ -254,6 +254,31 @@ export default class ImageBlock extends React.Component {
   }
 
   uploadFile() {
+    if (this.config.upload_handler) {
+      this.config.upload_handler(this.formatData().get('file'), this.updateProgressBar).then(url => {
+        this.uploadCompleted({ url })
+        this.props.blockProps.removeLock()
+        this.stopLoader()
+        this.file = null
+
+        if (this.config.upload_callback) {
+          return this.config.upload_callback(result, this)
+        }
+      }).catch(error => {
+        this.props.blockProps.removeLock()
+        this.stopLoader()
+
+        console.log(`ERROR: got error uploading file ${ error }`)
+        if (this.config.upload_error_callback) {
+          return this.config.upload_error_callback(error, this)
+        }
+      })
+
+      return handleUp = json_response => {
+        return this.uploadCompleted(json_response, n)
+      }
+    }
+
     let handleUp
     axios({
       method: 'post',

--- a/src/components/dante.js
+++ b/src/components/dante.js
@@ -92,6 +92,7 @@ class Dante {
         upload_url: options.upload_url,
         upload_headers: options.upload_headers,
         upload_formName: options.upload_formName,
+        upload_handler: options.image_upload_handler,
         upload_callback: options.image_upload_callback,
         image_delete_callback: options.image_delete_callback,
         image_caption_placeholder: options.image_caption_placeholder


### PR DESCRIPTION
This pull request adds support for specifying a custom image upload handler. This is useful in cases where someone wants to use a library for uploading an image rather than using an HTTP POST request (and the corresponding auth headers). 

The patch adds an `image_upload_handler` field to the configuration object which expects a callback function that takes `file` and `progressCallback` parameters. The function should return a promise that returns the uploaded image's URL on success. Meanwhile, `progressCallback` expects an object consumed by the `updateProgressBar` method in the ImageBlock component, namely one with `lengthComputable`, `loaded`, and `total` fields.

Here's some example code using this patch for uploading images to Firebase:

```javascript
import { Dante } from 'Dante2/dist/Dante2.js'
import uuidV1 from 'uuid/v1'

let dante2 = new Dante({
  el: 'editor-id',
  image_upload_handler: (file, progressCallback) => {
    const id = uuidV1()
    const promise = firebase.storage.ref().child(`foo-bar/${id}/${file.name}`).put(file)

    promise.on('state_changed', snapshot => {
      progressCallback({ lengthComputable: true, loaded: snapshot.bytesTransferred, total: snapshot.totalBytes })
    })

    return promise.then(data => {
      return new Promise((resolve, reject) => {
        resolve(data.downloadURL)
      })
    })
  },
  content: ''
})
dante2.render()

```