### PR TITLE
Added 'onKeyDown' event listener to ToolTip input

### DIFF
--- a/src/components/popovers/toolTip.js
+++ b/src/components/popovers/toolTip.js
@@ -1,17 +1,17 @@
 import React from 'react'
 import ReactDOM from 'react-dom'
 
-import { 
-  convertToRaw, 
-  CompositeDecorator, 
-  getVisibleSelectionRect, 
-  getDefaultKeyBinding, 
-  getSelectionOffsetKeyForNode, 
-  KeyBindingUtil, 
-  ContentState, 
-  Editor, 
-  EditorState, 
-  Entity, 
+import {
+  convertToRaw,
+  CompositeDecorator,
+  getVisibleSelectionRect,
+  getDefaultKeyBinding,
+  getSelectionOffsetKeyForNode,
+  KeyBindingUtil,
+  ContentState,
+  Editor,
+  EditorState,
+  Entity,
   RichUtils } from 'draft-js'
 
 import { getSelectionRect, getSelection } from "../../utils/selection.js"
@@ -207,7 +207,7 @@ class DanteTooltip extends React.Component {
       showPopLinkOver: this.props.showPopLinkOver,
       hidePopLinkOver: this.props.hidePopLinkOver
     }
-    
+
     let entityKey = Entity.create('LINK', 'MUTABLE', opts)
     //contentState.createEntity('LINK', 'MUTABLE', opts)
 
@@ -242,7 +242,7 @@ class DanteTooltip extends React.Component {
     if (this.refs.dante_menu_input) {
       this.refs.dante_menu_input.value = ""
     }
-    
+
     let currentBlock = getCurrentBlock(this.props.editorState)
     let blockType = currentBlock.getType()
     let selection = this.props.editor.state.editorState.getSelection()
@@ -281,7 +281,8 @@ class DanteTooltip extends React.Component {
             className="dante-menu-input"
             ref="dante_menu_input"
             placeholder={this.props.widget_options.placeholder}
-            onKeyPress={ this.handleInputEnter }
+            onKeyPress={this.handleInputEnter}
+            onKeyDown={this.handleInputEnter}
             defaultValue={ this.getDefaultValue() }
           />
           <div className="dante-menu-button" onMouseDown={ this._disableLinkMode } />


### PR DESCRIPTION
On certain browsers, an issue may come up where the 'onKeyPress' listener doesn't capture the enter key. To solve this issue,
'onKeyDown' listener was added to the input element and was bound to the same 'handleEnterInput' function. This should prevent
this issue in the future.