### PR TITLE
Update editor.js

### DIFF
--- a/src/components/core/editor.js
+++ b/src/components/core/editor.js
@@ -393,8 +393,6 @@ class DanteEditor extends React.Component {
         config: dataBlock.options
       }
     }
-
-    return null
   }
 
   blockStyleFn(block) {


### PR DESCRIPTION
`return null` statement is unreachable, so it should be removed.