### PR TITLE
avoid fake url in 'data_storage' prop while using 'save_handler'

### DIFF
--- a/src/editor/utils/save_content.js
+++ b/src/editor/utils/save_content.js
@@ -15,7 +15,8 @@ class SaveBehavior {
   }
 
   store(content){
-    if (!this.config.data_storage.url) { return }
+    if (!this.config.data_storage.url && !this.config.data_storage.save_handler) { return }
+    
     if (this.getLocks() > 0) { return }
 
     clearTimeout(this.timeout)


### PR DESCRIPTION
Include save_handler validation for storing data

sample reference using fake URL while using 'save_handler' function
https://codesandbox.io/s/1vp9p54rr4

In SaveBehavior.store(content) function, URL is validated which is needed in ajax call.
After introducing 'save_handler' as an alternate option for ajax calls, save_handler should also be considered for validation