### PR TITLE
add type="button" to buttons

### DIFF
--- a/src/editor/components/popovers/addButton.js
+++ b/src/editor/components/popovers/addButton.js
@@ -254,6 +254,7 @@ export default class DanteInlineTooltip extends React.Component {
         style={ this.state.position }
       >
         <button
+          type="button"
           className="inlineTooltip-button control"
           title="Close Menu"
           data-action="inline-menu"
@@ -296,6 +297,7 @@ class InlineTooltipItem extends React.Component {
   render() {
     return (
       <button
+        type="button"
         className="inlineTooltip-button scale"
         title={ this.props.title }
         onMouseDown={ this.clickHandler }

--- a/src/editor/components/popovers/select.js
+++ b/src/editor/components/popovers/select.js
@@ -78,7 +78,8 @@ class DropDown extends React.Component {
   render(){
     return (
       <div className={`dropdown ${this.state.open ? 'open' : ''}`} >
-        <button className="btn btn-default dropdown-toggle" 
+        <button type="button"
+                className="btn btn-default dropdown-toggle"
                 //onMouseDown={this.toggle}
                 type="button" id="dropdownMenu1" 
                 data-toggle="dropdown" 
@@ -105,7 +106,8 @@ class DropDownItem extends React.Component {
   render(){
     return (
       <li>
-        <button 
+        <button
+          type="button"
           onClick={(e)=> e.preventDefault()}
           onMouseDown={(e)=>this.props.handleClick(e, this.props.item)}>
           {this.props.item}


### PR DESCRIPTION
There were a bug without type="button". If Dante is used inside form, the form was submitted each time button is pressed. Adding type="button" fixed it. Otherwise these buttons were treated as type="submit".