### PR TITLE
accept images only on file upload

### DIFF
--- a/src/editor/components/popovers/addButton.js
+++ b/src/editor/components/popovers/addButton.js
@@ -275,6 +275,7 @@ export default class DanteInlineTooltip extends React.Component {
           }
           <input
            type="file"
+           accept="image/*"
            style={ { display: 'none' } }
            ref="fileInput"
            multiple="multiple"


### PR DESCRIPTION
This fix will show images only when upload file dialog is opened.