### PR TITLE
remove `.hidden` style from _utilities.scss

### DIFF
--- a/src/editor/styles/dante/_utilities.scss
+++ b/src/editor/styles/dante/_utilities.scss
@@ -53,7 +53,3 @@
   animation: spinner .6s linear infinite;
   -webkit-animation: spinner .6s linear infinite;
 }
-
-.hidden {
-  display: none !important;
-}


### PR DESCRIPTION
This style is unused in Dante2, but it could break the UI of people who use a `.hidden` class styling in their projects. Resolves #161 