### PR TITLE
preserve paragraph as block

### DIFF
--- a/src/editor/components/core/editor.js
+++ b/src/editor/components/core/editor.js
@@ -60,7 +60,7 @@ export default class DanteEditor extends React.Component {
       },
       'paragraph': {
         wrapper: null,
-        element: 'div'
+        element: 'p'
       },
       'placeholder': {
         wrapper: null,

--- a/src/editor/utils/html2content.js
+++ b/src/editor/utils/html2content.js
@@ -84,6 +84,12 @@ let customHTML2Content = function(HTML, blockRn){
   
   tempDoc.querySelectorAll('img').forEach( item=> imgReplacer(item))
 
+  // REPLACE NEW LINES WITH EMPTY SPACE WHEN COPY PASTING FROM WORD
+  var paras = tempDoc.getElementsByTagName('P');
+  for (var i = 0; i < paras.length; i++) {
+    paras[i].innerHTML = paras[i].innerHTML.replace(/(?:\r\n|\r|\n)/g, '');
+  };
+  
   // use DraftJS converter to do initial conversion. I don't provide DOMBuilder and
   // blockRenderMap arguments here since it should fall back to its default ones, which are fine
   // console.log(tempDoc.body.innerHTML)


### PR DESCRIPTION
When copy pasting from word it was connecting multiple paragraphs into 1 block. I've noticed that solution was already applied: https://stackoverflow.com/questions/39047832/draft-js-how-to-preserve-paragraph-breaks-when-pasting-content?rq=1

![image](https://user-images.githubusercontent.com/19556727/73858766-88c37e80-47fe-11ea-8ade-863e0fc328c5.png)
![image](https://user-images.githubusercontent.com/19556727/73858821-9da01200-47fe-11ea-862a-2c73198289d2.png)
