### PR TITLE
preserve paragraph as block

### DIFF
--- a/src/editor/components/core/editor.js
+++ b/src/editor/components/core/editor.js
@@ -60,7 +60,7 @@ export default class DanteEditor extends React.Component {
       },
       'paragraph': {
         wrapper: null,
-        element: 'div'
+        element: 'p'
       },
       'placeholder': {
         wrapper: null,


### PR DESCRIPTION
When copy pasting from word it was connecting multiple paragraphs into 1 block. I've noticed that solution was already applied: https://stackoverflow.com/questions/39047832/draft-js-how-to-preserve-paragraph-breaks-when-pasting-content?rq=1